### PR TITLE
chore: modernize dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                node-version: [16.x, 18.x, 20.x]
+                node-version: [20, 22, 24]
             fail-fast: false
 
         steps:

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = require('neostandard')({})

--- a/package.json
+++ b/package.json
@@ -37,8 +37,6 @@
     "eslint": "^9.27.0",
     "fastbench": "^1.0.1",
     "neostandard": "^0.12.1",
-    "tap-dot": "^2.0.0",
-    "tape": "^5.6.6",
     "tsd": "^0.32.0"
   },
   "browser": {

--- a/package.json
+++ b/package.json
@@ -5,9 +5,11 @@
   "main": "retimer.js",
   "types": "types.d.ts",
   "scripts": {
-    "lint": "standard",
-    "test": "npm run test:ci && npm run test:typescript",
-    "test:ci": "tape test.js | tap-dot",
+    "lint": "eslint",
+    "lint:fix": "eslint --fix",
+    "unit": "node --test test.js",
+    "test": "npm run unit && npm run test:typescript",
+    "test:ci": "npm run unit",
     "test:typescript": "tsd"
   },
   "pre-commit": [
@@ -31,18 +33,19 @@
   },
   "homepage": "https://github.com/mcollina/retimer#readme",
   "devDependencies": {
+    "@fastify/pre-commit": "^2.2.0",
+    "eslint": "^9.27.0",
     "fastbench": "^1.0.1",
-    "pre-commit": "^1.2.2",
-    "standard": "^17.1.0",
+    "neostandard": "^0.12.1",
     "tap-dot": "^2.0.0",
     "tape": "^5.6.6",
-    "tsd": "^0.28.1"
+    "tsd": "^0.32.0"
   },
   "browser": {
     "./time.js": "./time-browser.js",
     "./timers.js": "./timers-browser.js"
   },
   "dependencies": {
-    "worker-timers": "^7.0.75"
+    "worker-timers": "^8.0.21"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,117 +1,122 @@
 'use strict'
 
-const test = require('tape')
+const test = require('node:test')
 const retimer = require('./')
 
-test('schedule a callback', function (t) {
+test('schedule a callback', async function (t) {
   t.plan(1)
 
-  const start = Date.now()
+  await new Promise(resolve => {
+    const start = Date.now()
 
-  retimer(function () {
-    t.ok(Date.now() - start >= 50, 'it was deferred ok!')
-  }, 50)
+    retimer(function () {
+      t.assert.ok(Date.now() - start >= 50, 'it was deferred ok!')
+      resolve()
+    }, 50)
+  })
 })
 
-test('reschedule a callback', function (t) {
+test('reschedule multiple times', async function (t) {
   t.plan(1)
 
-  const start = Date.now()
+  await new Promise(resolve => {
+    const start = Date.now()
 
-  const timer = retimer(function () {
-    t.ok(Date.now() - start >= 70, 'it was deferred ok!')
-  }, 50)
+    const timer = retimer(function () {
+      t.assert.ok(Date.now() - start >= 90, 'it was deferred ok!')
+      resolve()
+    }, 50)
 
-  setTimeout(function () {
-    timer.reschedule(50)
-  }, 20)
-})
-
-test('reschedule multiple times', function (t) {
-  t.plan(1)
-
-  const start = Date.now()
-
-  const timer = retimer(function () {
-    t.ok(Date.now() - start >= 90, 'it was deferred ok!')
-  }, 50)
-
-  setTimeout(function () {
-    timer.reschedule(50)
     setTimeout(function () {
       timer.reschedule(50)
+      setTimeout(function () {
+        timer.reschedule(50)
+      }, 20)
     }, 20)
-  }, 20)
+  })
 })
 
-test('clear a timer', function (t) {
+test('clear a timer', async function (t) {
   t.plan(1)
+  await new Promise((resolve) => {
+    const timer = retimer(function () {
+      t.assert.ok(false, 'the timer should never get called')
+    }, 20)
 
-  const timer = retimer(function () {
-    t.fail('the timer should never get called')
-  }, 20)
+    timer.clear()
 
-  timer.clear()
-
-  setTimeout(function () {
-    t.pass('nothing happened')
-  }, 50)
-})
-
-test('clear a timer after a reschedule', function (t) {
-  t.plan(1)
-
-  const timer = retimer(function () {
-    t.fail('the timer should never get called')
-  }, 20)
-
-  setTimeout(function () {
-    timer.reschedule(50)
     setTimeout(function () {
-      timer.clear()
-    }, 10)
-  }, 10)
-
-  setTimeout(function () {
-    t.pass('nothing happened')
-  }, 50)
+      t.assert.ok(true, 'nothing happened')
+      resolve()
+    }, 50)
+  })
 })
 
-test('can be rescheduled early', function (t) {
+test('clear a timer after a reschedule', async function (t) {
+  t.plan(1)
+  await new Promise((resolve) => {
+    const timer = retimer(function () {
+      t.assert.ok(false, 'the timer should never get called')
+    }, 20)
+
+    setTimeout(function () {
+      timer.reschedule(50)
+      setTimeout(function () {
+        timer.clear()
+      }, 10)
+    }, 10)
+
+    setTimeout(function () {
+      t.assert.ok(true, 'nothing happened')
+      resolve()
+    }, 50)
+  })
+})
+
+test('can be rescheduled early', async function (t) {
   t.plan(1)
 
-  const start = Date.now()
+  await new Promise((resolve) => {
+    const start = Date.now()
 
-  const timer = retimer(function () {
-    t.ok(Date.now() - start <= 500, 'it was rescheduled!')
-  }, 500)
+    const timer = retimer(function () {
+      t.assert.ok(Date.now() - start <= 500, 'it was rescheduled!')
+      resolve()
+    }, 500)
 
-  setTimeout(function () {
-    timer.reschedule(10)
-  }, 20)
+    setTimeout(function () {
+      timer.reschedule(10)
+    }, 20)
+  })
 })
 
-test('can be rescheduled even if the timeout has already triggered', function (t) {
+test('can be rescheduled even if the timeout has already triggered', async function (t) {
   t.plan(2)
 
-  const start = Date.now()
-  let count = 0
+  await new Promise((resolve) => {
+    const start = Date.now()
+    let count = 0
 
-  const timer = retimer(function () {
-    count++
-    if (count === 1) {
-      t.ok(Date.now() - start >= 20, 'it was triggered!')
-      timer.reschedule(20)
-    } else {
-      t.ok(Date.now() - start >= 40, 'it was rescheduled!')
-    }
-  }, 20)
+    const timer = retimer(function () {
+      count++
+      if (count === 1) {
+        t.assert.ok(Date.now() - start >= 20, 'it was triggered!')
+        timer.reschedule(20)
+      } else {
+        t.assert.ok(Date.now() - start >= 40, 'it was rescheduled!')
+        resolve()
+      }
+    }, 20)
+  })
 })
 
-test('pass arguments to the callback', function (t) {
+test('pass arguments to the callback', async function (t) {
   t.plan(1)
 
-  retimer(function (arg) {
-    t.equal(arg, 42, 'argument matches')
-  }, 50, 42)
+  await new Promise((resolve) => {
+    retimer(function (arg) {
+      t.assert.equal(arg, 42, 'argument matches')
+      resolve()
+    }, 50, 42)
+  })
 })


### PR DESCRIPTION
This PR:

- updates all dependencies to their latest version, including worker-timer which had a medium vulnerability in its dependency chain , popping up when installing aedes.
- replaces  devdependencies to remove vulnerability warnings during development:
  - tape and tap-dot by node:test 
  - standard by eslint & neostandard
  - pre-commit by @fastify-precommit
- updates CI to use Nodejs 20, 22 , 24
Kind regards,
Hans